### PR TITLE
Add in basic field masking into example

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ Each example contains extensive inline documentation explaining each line of cod
 The code in the `main` source tree is shared between all examples. It includes the bulk of the application, including all the activities. The following SOS features are demonstrated in all flavors:
 
 - **Hiding and showing the SOS button**: The SOS button shown in the actionbar on the Contacts, Profiles, and Compose activities will be hidden when the SOS session starts, and shown again when it ends. See the code in `SubActivity.java` to understand how this works.
+- **Masking the message field**: The message field of the Compose activity is masked using the default masking functionality. The field is visible whenever it has focus for editing and is hidden otherwise.
 
 ### Simple
 

--- a/app/src/main/res/layout/activity_compose.xml
+++ b/app/src/main/res/layout/activity_compose.xml
@@ -20,7 +20,23 @@
         android:layout_width="match_parent"
         android:layout_height="wrap_content"/>
 
-    <EditText
+    <!--
+    The most direct way to make a masked field is to use the SOS masked equivalent of an
+    existing Android field. Currently, the following maskable fields are available:
+        com.salesforce.android.sos.mask.EditText,
+        com.salesforce.android.sos.mask.AutoCompleteTextView,
+        com.salesforce.android.sos.mask.MultiAutoCompleteTextView,
+        com.salesforce.android.sos.mask.TextView,
+        com.salesforce.android.sos.mask.View
+
+    The first three of these masked-field types are editable and exposing and hiding of those
+    fields is handled automatically whenever the field has focus. It is possible to expose or
+    hide any of the masked fields programmatically.
+
+    Additionally, the actual drawable that acts as the mask (a gray rectangle by default) can
+    be customized with an application-defined drawable asset.
+    -->
+    <com.salesforce.android.sos.mask.EditText
         android:hint="@string/hint_message"
         android:inputType="textMultiLine"
         android:layout_width="match_parent"


### PR DESCRIPTION
Closes #3 

This is the most basic field masking example. It simply alters the base class for the EditText used in the layout. Documentation is in the layout file with a short blurb in the README.
