### PR TITLE
(#5): Use a custom view for showing the connecting status.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Each example contains extensive inline documentation explaining each line of cod
 
 The code in the `main` source tree is shared between all examples. It includes the bulk of the application, including all the activities. The following SOS features are demonstrated in all flavors:
 
-- **Hiding and showing the SOS button**: The SOS button shown in the actionbar on the Contacts, Profiles, and Compose activities will be hidden when the SOS session starts, and shown again when it ends. See the code in `SubActivity.java` to understand how this works.
+- **Hiding and showing the SOS button**: The SOS button shown in the actionbar on the Contacts, Profiles, and Compose activities, and the main content of the main activity, will be hidden when the SOS session starts, and shown again when it ends. See the code in `SubActivity.java` or `MainActivity.java` to understand how this works.
 - **Masking the message field**: The message field of the Compose activity is masked using the default masking functionality. The field is visible whenever it has focus for editing and is hidden otherwise.
 
 ### Simple
@@ -62,4 +62,7 @@ to the Agent.  Since Toasts live outside of the activity view hierarchy, they ar
 
 ### Advanced
 
-The `advanced` flavor includes some of the basic configuration done in the above example, as well as more advanced configuration in the `SosConnector` class. This example overrides some of the dialog presentation logic in order to bypass the disconnection confirmation prompt (the user will not be prompted when choosing to disconnect).
+The `advanced` flavor includes some of the basic configuration done in the above example, as well as more advanced configuration in the `SosConnector` class. This example overrides some of the dialog presentation logic in order to:
+
+- Bypass the disconnection confirmation prompt (the user will not be prompted when choosing to disconnect).
+- Use a custom view for showing the connection status on the MainActivity.

--- a/app/src/advanced/java/com/salesforce/androidsosguides/sos/ExampleDialogPresenter.java
+++ b/app/src/advanced/java/com/salesforce/androidsosguides/sos/ExampleDialogPresenter.java
@@ -1,8 +1,11 @@
 package com.salesforce.androidsosguides.sos;
 
 import android.app.Activity;
+import android.app.FragmentManager;
 
 import com.salesforce.android.sos.api.SosDefaultDialogPresenter;
+import com.salesforce.androidsosguides.MainActivity;
+import com.salesforce.androidsosguides.R;
 
 /**
  * This example dialog presenter is used to replace some of the default dialog presentation logic
@@ -11,6 +14,9 @@ import com.salesforce.android.sos.api.SosDefaultDialogPresenter;
  * not use any of the default dialog presenting logic.
  */
 public class ExampleDialogPresenter extends SosDefaultDialogPresenter {
+  /**
+   * @{inheritDoc}
+   */
   @Override
   public void show(Type type, Activity activity, Callback callback) {
 
@@ -23,7 +29,83 @@ public class ExampleDialogPresenter extends SosDefaultDialogPresenter {
       return;
     }
 
+    // Use a custom fragment to show the connection status UI on the main activity only. Other
+    // activities will use the default logic.
+    if (type == Type.CONNECTING_STATUS && activity instanceof MainActivity) {
+      showCustomFragment(activity, callback);
+      return;
+    }
+
     // Call through to the default logic for all other dialog types.
     super.show(type, activity, callback);
+  }
+
+  /**
+   * @{inheritDoc}
+   */
+  @Override
+  public void setMessage(Type type, Activity activity, int resourceId) {
+    // Update our custom status fragment on the main activity.
+    if (type == Type.CONNECTING_STATUS && activity instanceof MainActivity) {
+      setCustomFragmentMessage(activity, resourceId);
+      return;
+    }
+
+    // Call through to the default logic for all other dialog types.
+    super.setMessage(type, activity, resourceId);
+  }
+
+  /**
+   * @{inheritDoc}
+   */
+  @Override
+  public void dismiss(Type type, Activity activity) {
+    // Remove our custom status fragment on the main activity.
+    if (type == Type.CONNECTING_STATUS && activity instanceof MainActivity) {
+      dismissCustomFragment(activity);
+      return;
+    }
+
+    // Call through to the default logic for all other dialog types.
+    super.dismiss(type, activity);
+  }
+
+  // Custom fragment methods.
+
+  private void showCustomFragment(Activity activity, Callback callback) {
+    // Get the message from the type.
+    String message = Type.CONNECTING_STATUS.getMessage(activity);
+
+    // Instantiate the fragment we're going to be showing.
+    StatusFragment fragment = StatusFragment.newInstance(message, callback);
+
+    // Add the fragment to the activity.
+    activity.getFragmentManager().beginTransaction()
+        .add(R.id.status_fragment_container, fragment)
+        .commit();
+  }
+
+  private void setCustomFragmentMessage(Activity activity, int resourceId) {
+    // Find the fragment in the activity.
+    FragmentManager manager = activity.getFragmentManager();
+    StatusFragment fragment = (StatusFragment) manager.findFragmentById(R.id.status_fragment_container);
+
+    // Set the message in the fragment.
+    if (fragment != null) {
+      fragment.setMessage(activity.getResources().getString(resourceId));
+    }
+  }
+
+  private void dismissCustomFragment(Activity activity) {
+    // Find the fragment in the activity.
+    FragmentManager manager = activity.getFragmentManager();
+    StatusFragment fragment = (StatusFragment) manager.findFragmentById(R.id.status_fragment_container);
+
+    // Remove the fragment.
+    if (fragment != null) {
+      manager.beginTransaction()
+          .remove(fragment)
+          .commit();
+    }
   }
 }

--- a/app/src/advanced/java/com/salesforce/androidsosguides/sos/StatusFragment.java
+++ b/app/src/advanced/java/com/salesforce/androidsosguides/sos/StatusFragment.java
@@ -1,0 +1,83 @@
+package com.salesforce.androidsosguides.sos;
+
+import android.app.Fragment;
+import android.os.Bundle;
+import android.support.annotation.Nullable;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.salesforce.android.sos.api.SosDialogPresenter;
+import com.salesforce.androidsosguides.R;
+
+/**
+ * This fragment is used to show the SOS connection status on the main activity.
+ */
+public class StatusFragment extends Fragment implements View.OnClickListener {
+
+  private View view;
+  private String message;
+  private SosDialogPresenter.Callback callback;
+
+  public static StatusFragment newInstance(String message, SosDialogPresenter.Callback callback) {
+    StatusFragment fragment = new StatusFragment();
+
+    Bundle args = new Bundle();
+    args.putString("message", message);
+    args.putSerializable("callback", callback);
+    fragment.setArguments(args);
+
+    return fragment;
+  }
+
+  @Override
+  public void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    // If the message had been previously set via a call to setMessage then it'll be present in the
+    // saved instance state. Otherwise read the message from the arguments provided to the fragment.
+    if (savedInstanceState != null && savedInstanceState.get("message") != null) {
+      message = savedInstanceState.getString("message");
+    } else {
+      message = getArguments().getString("message");
+    }
+
+    // Read the callback from the fragment arguments.
+    callback = (SosDialogPresenter.Callback) getArguments().get("callback");
+  }
+
+  @Override
+  public void onSaveInstanceState(Bundle outState) {
+    super.onSaveInstanceState(outState);
+    outState.putString("message", message);
+  }
+
+  @Nullable
+  @Override
+  public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+    view = inflater.inflate(R.layout.fragment_status, container, false);
+
+    TextView status = (TextView) view.findViewById(R.id.fragment_status_text);
+    status.setText(message);
+
+    Button cancel = (Button) view.findViewById(R.id.fragment_status_button);
+    cancel.setOnClickListener(this);
+
+    return view;
+  }
+
+  @Override
+  public void onClick(View v) {
+    // When the user clicks the button, tell the SOS framework that they chose to cancel the
+    // connection by calling the provided callback.
+    callback.complete(SosDialogPresenter.Type.CONNECTING_STATUS, false, getActivity());
+  }
+
+  public void setMessage(String message) {
+    this.message = message;
+    TextView status = (TextView) view.findViewById(R.id.fragment_status_text);
+    status.setText(message);
+  }
+}

--- a/app/src/advanced/res/layout/fragment_status.xml
+++ b/app/src/advanced/res/layout/fragment_status.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- This layout contains the views that are embedded into the MainActivity during the SOS
+     connecting phase. -->
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              android:orientation="vertical"
+              android:layout_width="match_parent"
+              android:layout_height="wrap_content"
+              android:gravity="center_horizontal">
+
+    <TextView
+        android:text="@string/connecting_to_sos"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <!-- This textview will be used to show the status of the connection. -->
+    <TextView
+        android:id="@+id/fragment_status_text"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+    <!-- This button can be used to cancel the connection. -->
+    <Button
+        android:id="@+id/fragment_status_button"
+        android:text="@string/sos_connect_negative"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"/>
+
+</LinearLayout>

--- a/app/src/advanced/res/values/strings.xml
+++ b/app/src/advanced/res/values/strings.xml
@@ -1,3 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
+
+    <!-- Content for our custom status fragment -->
+    <string name="connecting_to_sos">We\'re connecting you to a service agent.</string>
+
 </resources>

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -7,14 +7,21 @@
               android:paddingTop="@dimen/activity_vertical_margin"
               android:paddingBottom="@dimen/activity_vertical_margin"
               android:gravity="center"
+              android:orientation="vertical"
               tools:context=".MainActivity">
 
     <ImageButton
+        android:id="@+id/start_sos_button"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:src="@drawable/button_sos"
         android:contentDescription="@string/start_sos"
         android:onClick="startSos"
         android:padding="0dp"/>
+
+    <RelativeLayout
+        android:id="@+id/status_fragment_container"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
 
 </LinearLayout>


### PR DESCRIPTION
Closes #5.
- Hides the SOS button on the main activity while the session is active.
- Replaces the dialog logic for showing the connecting status on the MainActivity. Shows an inline view in a fragment instead.
